### PR TITLE
Improve border alignment

### DIFF
--- a/EOIR_Simulator/View/MainView.xaml
+++ b/EOIR_Simulator/View/MainView.xaml
@@ -70,7 +70,7 @@
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
 
-            <Border BorderBrush="Gray" BorderThickness="1" Margin="0,0,0,8" Padding="8">
+            <Border BorderBrush="Gray" BorderThickness="1" Margin="0,0,0,8" Padding="8" Width="280" Height="100" HorizontalAlignment="Center">
                 <StackPanel>
 
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,0,0,6">
@@ -82,21 +82,22 @@
                         <TextBlock Text="운용 선택" FontSize="14" VerticalAlignment="Center" Margin="0,0,8,0"/>
                         <Button Content="Run" Command="{Binding SetManualModeCommand}" IsEnabled="{Binding IsTcpConnected}" Width="70"/>
                     </StackPanel>
+                </StackPanel>
+            </Border>
 
-                    
-                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,22.5">
-                        <TextBlock Text="모드 선택 :" VerticalAlignment="Center" Margin="0,0,6,0"/>
-                        <ComboBox SelectedValue="{Binding Mode, Mode=TwoWay}" SelectedValuePath="Tag" Width="120" Height="30" VerticalContentAlignment="Center">
-                            <ComboBoxItem Content="수동 모드 (기본)" Tag="{x:Static model:ModeNum.Manual}"/>
-                            <ComboBoxItem Content="스캔 모드" Tag="{x:Static model:ModeNum.Scan}"/>
-                            <ComboBoxItem Content="추적 모드 (자동)" Tag="{x:Static model:ModeNum.Track}" IsEnabled="False"/>
-                        </ComboBox>
-                    </StackPanel>
+            <Border BorderBrush="Gray" BorderThickness="1" Margin="0,0,0,8" Padding="8" Width="280" Height="100" HorizontalAlignment="Center">
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,22.5">
+                    <TextBlock Text="모드 선택 :" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                    <ComboBox SelectedValue="{Binding Mode, Mode=TwoWay}" SelectedValuePath="Tag" Width="120" Height="30" VerticalContentAlignment="Center">
+                        <ComboBoxItem Content="수동 모드 (기본)" Tag="{x:Static model:ModeNum.Manual}"/>
+                        <ComboBoxItem Content="스캔 모드" Tag="{x:Static model:ModeNum.Scan}"/>
+                        <ComboBoxItem Content="추적 모드 (자동)" Tag="{x:Static model:ModeNum.Track}" IsEnabled="False"/>
+                    </ComboBox>
                 </StackPanel>
             </Border>
 
             <StackPanel Grid.Row="1">
-                
+                <Border BorderBrush="Gray" BorderThickness="1" Padding="8" Margin="0,0,0,8" Width="280" Height="180" HorizontalAlignment="Center">
                     <StackPanel>
                         <TextBlock Text="서보 제어" HorizontalAlignment="Center" FontWeight="Bold" Margin="0,4"/>
                         <Grid HorizontalAlignment="Center" Margin="0,20">
@@ -114,8 +115,11 @@
                             <RepeatButton Content="↓" Command="{Binding MoveCommand}" CommandParameter="Down" Grid.Row="1" Grid.Column="1" Width="50" Height="50" Margin="4"/>
                             <RepeatButton Content="→" Command="{Binding MoveCommand}" CommandParameter="Right" Grid.Row="1" Grid.Column="2" Width="50" Height="50" Margin="4"/>
                         </Grid>
+                    </StackPanel>
+                </Border>
 
-                    <StackPanel HorizontalAlignment="Center" Margin="0,20">
+                <Border BorderBrush="Gray" BorderThickness="1" Padding="8" Margin="0,0,0,8">
+                    <StackPanel HorizontalAlignment="Center">
                         <TextBlock Text="전처리 옵션 선택" HorizontalAlignment="Center" FontWeight="Bold" Margin="0,4"/>
                         <ComboBox Width="160"
                                   Height="40"
@@ -133,50 +137,51 @@
                             <ComboBoxItem Content="열화상/IR" />
                         </ComboBox>
                     </StackPanel>
-                </StackPanel>
+                </Border>
 
                 <TextBlock Text="Log:" FontWeight="Bold" Margin="8,8,8,4"/>
-                <!--<ListBox Height="400" Margin="8" BorderBrush="Gray" BorderThickness="1" />-->
-                <ListBox x:Name="LogListBox"
-                         ItemsSource="{Binding TcpLogs}"
-                         Height="400" Margin="8"
-                         FontFamily="Consolas" FontSize="12"
-                         BorderBrush="Gray" BorderThickness="1"
-                         VerticalContentAlignment="Top">
-                    <ListBox.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <StackPanel />
-                        </ItemsPanelTemplate>
-                    </ListBox.ItemsPanel>
-                </ListBox>
+                <Border BorderBrush="Gray" BorderThickness="1" Margin="0,0,0,4">
+                    <!--<ListBox Height="400" Margin="8" BorderBrush="Gray" BorderThickness="1" />-->
+                    <ListBox x:Name="LogListBox"
+                             ItemsSource="{Binding TcpLogs}"
+                             Height="400" Margin="8"
+                             FontFamily="Consolas" FontSize="12"
+                             VerticalContentAlignment="Top">
+                        <ListBox.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel />
+                            </ItemsPanelTemplate>
+                        </ListBox.ItemsPanel>
+                    </ListBox>
+                </Border>
 
             </StackPanel>
         </Grid>
 
         <!-- 중앙 오른쪽 상태 및 결과 -->
         <StackPanel Grid.Column="1" Margin="4">
-            <Border BorderBrush="Gray" BorderThickness="1" Margin="0,0,0,4">
-                <StackPanel Orientation="Horizontal" Margin="12,4">
-                    <Ellipse Width="12" Height="12" Fill="{Binding Connection.TcpStateColor}" Stroke="Black" StrokeThickness="1" Margin="0,0,6,0"/>
-                    <TextBlock Text="{Binding Connection.TcpStatus}" FontSize="13" FontWeight="Bold"/>
-                </StackPanel>
-            </Border>
-            <Border BorderBrush="Gray" BorderThickness="1" Margin="0,0,0,4">
-                <StackPanel Orientation="Horizontal" Margin="12,4">
-                    <Ellipse Width="12" Height="12" Fill="{Binding Connection.UdpStateColor}" Stroke="Black" StrokeThickness="1" Margin="0,0,6,0"/>
-                    <TextBlock Text="{Binding Connection.UdpStatus}" FontSize="13" FontWeight="Bold"/>
-                </StackPanel>
-            </Border>
-            <Border BorderBrush="Gray" BorderThickness="1" Margin="0,0,0,4">
+            <Border BorderBrush="Gray" BorderThickness="1" Margin="0,0,0,4" Width="280" Height="100" HorizontalAlignment="Center" Padding="8">
                 <StackPanel>
-                    <TextBlock Text="현재 모드" HorizontalAlignment="Center" Margin="0,4"/>
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,4" HorizontalAlignment="Center">
+                        <Ellipse Width="12" Height="12" Fill="{Binding Connection.TcpStateColor}" Stroke="Black" StrokeThickness="1" Margin="0,0,6,0"/>
+                        <TextBlock Text="{Binding Connection.TcpStatus}" FontSize="13" FontWeight="Bold"/>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                        <Ellipse Width="12" Height="12" Fill="{Binding Connection.UdpStateColor}" Stroke="Black" StrokeThickness="1" Margin="0,0,6,0"/>
+                        <TextBlock Text="{Binding Connection.UdpStatus}" FontSize="13" FontWeight="Bold"/>
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+            <Border BorderBrush="Gray" BorderThickness="1" Margin="0,0,0,4" Width="280" Height="100" HorizontalAlignment="Center" Padding="8">
+                <StackPanel>
+                    <TextBlock Text="현재 모드" HorizontalAlignment="Center" Margin="0,0,0,4"/>
                     <Border BorderBrush="Gray" BorderThickness="1" Margin="8" Height="40">
                         <TextBlock Text="{Binding Mode}" FontWeight="Bold" HorizontalAlignment="Center" VerticalAlignment="Center"/>
                     </Border>
                 </StackPanel>
             </Border>
            
-            <Border Height="180" BorderBrush="Gray" BorderThickness="1" Margin="2,2,4,4">
+            <Border Height="180" Width="280" HorizontalAlignment="Center" BorderBrush="Gray" BorderThickness="1" Margin="2,2,4,4">
                 <Grid>
                     <h:HelixViewport3D ShowCoordinateSystem="False" ZoomExtentsWhenLoaded="True" Background="Black">
                         <h:SunLight/>
@@ -192,18 +197,20 @@
                     </StackPanel>
                 </Grid>
             </Border>
-            <TextBlock Text="Detection Result:" FontWeight="Bold" Margin="8,8,8,4"/>
-            <Border BorderBrush="Gray" BorderThickness="1" Margin="0,0,0,4">
-                <DataGrid Margin="4" Height="160" ItemsSource="{Binding Video.Objects}" AutoGenerateColumns="False" IsReadOnly="True" HeadersVisibility="Column">
-                    <DataGrid.Columns>
-                        <DataGridTextColumn Header="Cls" Binding="{Binding Class}" Width="50"/>
-                        <DataGridTextColumn Header="X" Binding="{Binding X}" Width="50"/>
-                        <DataGridTextColumn Header="Y" Binding="{Binding Y}" Width="50"/>
-                        <DataGridTextColumn Header="W" Binding="{Binding W}" Width="50"/>
-                        <DataGridTextColumn Header="H" Binding="{Binding H}" Width="50"/>
-                        <DataGridTextColumn Header="Conf" Binding="{Binding Confidence, StringFormat=F2}" Width="*"/>
-                    </DataGrid.Columns>
-                </DataGrid>
+            <Border BorderBrush="Gray" BorderThickness="1" Margin="0,0,0,4" Padding="4">
+                <StackPanel>
+                    <TextBlock Text="Detection Result:" FontWeight="Bold" Margin="0,0,0,4"/>
+                    <DataGrid Height="160" ItemsSource="{Binding Video.Objects}" AutoGenerateColumns="False" IsReadOnly="True" HeadersVisibility="Column">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Cls" Binding="{Binding Class}" Width="50"/>
+                            <DataGridTextColumn Header="X" Binding="{Binding X}" Width="50"/>
+                            <DataGridTextColumn Header="Y" Binding="{Binding Y}" Width="50"/>
+                            <DataGridTextColumn Header="W" Binding="{Binding W}" Width="50"/>
+                            <DataGridTextColumn Header="H" Binding="{Binding H}" Width="50"/>
+                            <DataGridTextColumn Header="Conf" Binding="{Binding Confidence, StringFormat=F2}" Width="*"/>
+                        </DataGrid.Columns>
+                    </DataGrid>
+                </StackPanel>
             </Border>
         </StackPanel>
     </Grid>


### PR DESCRIPTION
## Summary
- standardize widths and heights across key borders
- merge TCP/UDP status into a single group
- separate mode selection from connection panel
- match helix viewer and servo control sizes

## Testing
- `dotnet build EOIR_Simulator.sln` *(fails: dotnet not installed)*


------
https://chatgpt.com/codex/tasks/task_e_6842f7e8bbc4832aad85cfe23da20ff1